### PR TITLE
Run skunk in the correct branch

### DIFF
--- a/.github/workflows/skunk.yml
+++ b/.github/workflows/skunk.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Skunk on Project
         run: |
           gem install skunk
-          rm Gemfile.lock
+          git checkout Gemfile.lock
           CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
           if [[ "$CURRENT_BRANCH" != "master" ]]; then
             echo "Executing within branch: $CURRENT_BRANCH"

--- a/.github/workflows/skunk.yml
+++ b/.github/workflows/skunk.yml
@@ -54,7 +54,7 @@ jobs:
           CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
           if [[ "$CURRENT_BRANCH" != "master" ]]; then
             echo "Executing within branch: $CURRENT_BRANCH"
-            skunk . -b master
+            skunk . -b main
           else
             echo "Executing within master branch"
             skunk .


### PR DESCRIPTION
Closes https://github.com/fastruby/skunk.fyi/issues/9

Run skunk in the `main` branch instead of `master`