### PR TITLE
Add a bin/yarn script so heroku runs yarn install during deploy

### DIFF
--- a/bin/yarn
+++ b/bin/yarn
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+APP_ROOT = File.expand_path('..', __dir__)
+Dir.chdir(APP_ROOT) do
+  begin
+    exec "yarnpkg", *ARGV
+  rescue Errno::ENOENT
+    $stderr.puts "Yarn executable was not detected in the system."
+    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    exit 1
+  end
+end


### PR DESCRIPTION
Looks like new rails apps includes this file and Heroku uses it to detect if it needs to run `yarn install` during the deploy.

closing https://github.com/fastruby/skunk.fyi/issues/12