### PR TITLE
Scope Dependabot, force SSL in production, drop .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,0 @@
-# Committed on purpose: the madmin admin panel is behind HTTP basic auth built
-# from these variables, and `http_basic_authenticate_with` raises if they are nil.
-# CI has no .env, so the admin tests need these to come from somewhere.
-ADMIN_USERNAME=test-admin
-ADMIN_PASSWORD=test-password

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "bundler"
+    # Rails itself is dual booted from the Gemfile, so version bumps to it have
+    # to be driven by an upgrade PR that updates both lockfiles and runs QA on
+    # both boots, not by Dependabot.
+    ignore:
+      - dependency-name: rails
+      - dependency-name: railties
+      - dependency-name: activesupport
+      - dependency-name: activerecord
+      - dependency-name: actionpack
+      - dependency-name: actionview
+    # One PR per group keeps the queue reviewable; anything major still gets its
+    # own PR so it is never bundled with routine noise.
+    groups:
+      bundler-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "npm"
+    # These are unresolvable while webpacker 5 is pinned, and Dependabot errors
+    # out trying: @rails/webpacker@5.4.3 and webpack-dev-server@3.11.0 both pin
+    # minimatch@3.1.2, which requires brace-expansion@^1.1.7. A failed run stamps
+    # a failing check on the head commit of main, which blocks the Heroku
+    # auto-deploy gate. Ignore conditions apply to security updates too, so this
+    # is what stops the noise.
+    #
+    # This trades the advisory alerts for a working deploy pipeline. They are not
+    # patchable today either way. Drop these entries the moment webpacker is
+    # replaced, which is the actual fix.
+    ignore:
+      - dependency-name: brace-expansion
+      - dependency-name: minimatch
+      - dependency-name: tar
+      - dependency-name: postcss
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  # Nothing was watching these: the workflows still pin actions/checkout@v1,
+  # which was released in 2019 and runs on a Node version GitHub has retired.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,16 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  # The admin panel authenticates with HTTP basic auth, so without this the
+  # credentials travel in cleartext on any plain http:// request.
+  config.force_ssl = true
+
+  # Rails defaults HSTS to a two year max-age, which browsers honour and cache
+  # per host. That is effectively irreversible: until it expires, a browser that
+  # has seen the header refuses to talk to this host over http at all, so a
+  # misconfiguration cannot be backed out by shipping a fix. Start short, confirm
+  # the redirect works against the real Heroku router, then raise it.
+  config.ssl_options = { hsts: { expires: 1.week, subdomains: true } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,14 @@
 ENV["RAILS_ENV"] ||= "test"
+
+# The madmin panel authenticates with HTTP basic auth built from these, and
+# `http_basic_authenticate_with` raises when they are nil, so the admin tests need
+# them to come from somewhere. Set here rather than in a committed .env.test so
+# that nothing credential-shaped lives in the repo, and set before the
+# environment is loaded because Madmin::ApplicationController reads them at
+# class-definition time.
+ENV["ADMIN_USERNAME"] ||= "test-admin"
+ENV["ADMIN_PASSWORD"] ||= "test-password"
+
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 


### PR DESCRIPTION
**Description:**

Three related cleanups that came out of reviewing #129 and chasing down why Heroku auto-deploy had not fired.

## Dependabot had no config at all

There is no `.github/dependabot.yml` on `main`, so Dependabot was running **security updates only**, on its own schedule, with no scoping. Those runs fail on every push to `main`:

```
@rails/webpacker@5.4.3 requires brace-expansion@^1.1.7
  via a transitive dependency on minimatch@3.1.2
webpack-dev-server@3.11.0 requires brace-expansion@^1.1.7
  via a transitive dependency on minimatch@3.1.2

Error: The updater encountered one or more errors.
```

The npm advisories cannot be resolved while webpacker 5 is pinned, Dependabot errors out trying, and a failed run stamps a **failing check on the head commit of `main`**. That is what the Heroku auto-deploy CI gate reads, so it would have kept blocking deploys indefinitely. On `f3681a6`:

```
test-rails-current   success
test-rails-next      success
skunk                success
Dependabot           failure
Dependabot           failure
Dependabot           failure
```

Ignore conditions in `dependabot.yml` apply to security updates as well as version updates, so ignoring that transitive chain (`brace-expansion`, `minimatch`, `tar`, `postcss`) is what actually stops the failures.

This is an explicit trade: we give up advisory alerts we cannot act on today in exchange for a deploy pipeline that works. Replacing webpacker is the real fix, and those four entries should go the moment it lands.

While in there:

- **Weekly**, Monday 06:00 UTC, instead of Dependabot's default cadence.
- **Grouped minor/patch PRs** per ecosystem so the queue stays reviewable. Majors still get their own PR and are never bundled with routine noise.
- **Rails is pinned out of Dependabot's hands.** The app is dual booted, so a Rails bump has to move `Gemfile.lock` *and* `Gemfile.next.lock` together and be QA'd on both boots. Dependabot only knows about `Gemfile`, so an unsupervised bump would silently drift the two lockfiles apart.
- **`github-actions` is now watched**, which nothing was doing. All three jobs still pin `actions/checkout@v1`, released in 2019 and running on a Node runtime GitHub has retired.

## force_ssl in production

`config.force_ssl` was commented out. The madmin panel authenticates with HTTP basic auth, so those credentials travel in cleartext on any plain `http://` request. Enabled.

**HSTS max-age is deliberately set to one week, not the Rails default of two years.** Browsers cache HSTS per host and honour it strictly: until it expires, a browser that has seen the header refuses to talk to the host over http at all, which means a misconfiguration cannot be backed out by shipping a fix. Starting short makes it reversible. Raise it to a year once the redirect is confirmed against the real Heroku router.

Two effects worth being aware of before this deploys:

1. `ActionDispatch::SSL` redirects `GET`/`HEAD` with **301** and every other method with **307** to preserve it. `Net::HTTP` does not follow redirects, so any client posting to `http://` gets the redirect object back rather than a report id. The skunk CLI is fine: `DEFAULT_URL` is `https://skunk.fastruby.io`. Only a client with `SHARE_URL` explicitly set to `http://` would break, and it would break loudly.
2. Heroku terminates TLS at the router and forwards `X-Forwarded-Proto`, which is what `ActionDispatch::SSL` reads, so the redirect resolves correctly rather than looping.

## Dropped .env.test

#129 added a committed `.env.test` to supply `ADMIN_USERNAME` / `ADMIN_PASSWORD`, because `http_basic_authenticate_with` raises when they are nil and CI has no `.env`. Replaced with two lines in `test_helper.rb`, so nothing credential-shaped is committed.

They have to be set **before** `config/environment` is required, because `Madmin::ApplicationController` reads them at class-definition time.

## Verification

Full suite green on both boots with eager loading on and `.env` moved aside, matching CI exactly:

```
7.0  23 runs, 42 assertions, 0 failures, 0 errors, 0 skips
7.1  23 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```

`bundle exec rubocop` clean. `.github/dependabot.yml` parses and resolves to three ecosystems, all weekly. Production config loads on both boots with `force_ssl=true` and `ssl_options={:hsts=>{:expires=>1 week, :subdomains=>true}}`.

## Follow-ups, not in this PR

- Replacing webpacker is what actually clears the npm advisories and lets the four ignore entries go.
- Raise HSTS max-age after confirming the redirect in production.
- `config.load_defaults` is still `6.0`, and 7.1 warns that both `cache_format_version = 6.1` and `secret_key_base` in `Rails.application.secrets` are removed in 7.2. All three belong to the 7.1 → 7.2 step.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).
